### PR TITLE
Move vscode package to be a dev dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,12 +100,12 @@
     "devDependencies": {
         "@types/mocha": "^2.2.48",
         "@types/node": "^6.0.102",
-        "mocha": "^2.3.3"
+        "mocha": "^2.3.3",
+        "vscode": "^1.1.18"
     },
     "dependencies": {
         "growl": "^1.10.5",
         "tslint": "^5.10.0",
-        "typescript": "^2.9.1",
-        "vscode": "^1.1.18"
+        "typescript": "^2.9.1"
     }
 }


### PR DESCRIPTION
vscode doesn't need to be part of the node dependencies, and will end up giving issues with vulnerabilities tools like synk, 
which will report the dependencies to support  "Regular Expression Denial of Service (ReDoS)"

The solution is to move to into a dev dependency where it doesn't affect the production version of this package.