### PR TITLE
Enable AutoCompletion for unsaved documents

### DIFF
--- a/src/mxsMain.ts
+++ b/src/mxsMain.ts
@@ -6,7 +6,7 @@ import mxsCompletion from './mxsAutocomplete';
 import mxsOutline from './mxsOutline';
 import msxDefinitions from './mxsDefinitions';
 // Constants
-export const MXS_MODE: vscode.DocumentFilter = { scheme: 'file', language: 'maxscript' };
+export const MXS_MODE: vscode.DocumentFilter = { language: 'maxscript' };
 export const LANG_CFG: vscode.LanguageConfiguration = {
 	indentationRules: {
 		increaseIndentPattern: /^.*(\([^)]*|\b(?:[tT]hen|[eE]lse|[wW]ith|[dD]o|[cC]ollect|of)\b\s*)$/,


### PR DESCRIPTION
by now mxs autocomplete is limited to only saved documents which isn't convenient when maxscript is set as default vscode language
